### PR TITLE
修复Windows环境监测

### DIFF
--- a/BaseType.h
+++ b/BaseType.h
@@ -3,3 +3,10 @@
 #ifdef __linux
 #define linux
 #endif // __linux
+
+#ifndef WIN32
+#ifdef _WIN32
+#define WIN32
+#endif
+#endif
+


### PR DESCRIPTION
原来的判断Windows环境有问题，不能使用WIN32宏定义判断，应该使用_WIN32判断